### PR TITLE
chore: compose product import template fix for issue 76

### DIFF
--- a/.github/workflows/product-module-composition-check.yml
+++ b/.github/workflows/product-module-composition-check.yml
@@ -1,0 +1,18 @@
+name: Product Module Composition Check
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - task-76
+
+jobs:
+  verify-products-module-pointer:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify products module pointer
+        run: node tools/verify-products-module-pointer.cjs

--- a/tools/verify-products-module-pointer.cjs
+++ b/tools/verify-products-module-pointer.cjs
@@ -1,0 +1,29 @@
+const {execFileSync} = require('child_process');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..');
+const expectedCommit = '1ecd6876e1591597f4eeddc96a7e93ce19232549';
+const submodulePath = 'modules/controleonline/products';
+
+const output = execFileSync(
+  'git',
+  ['ls-files', '--stage', submodulePath],
+  {cwd: root, encoding: 'utf8'},
+).trim();
+
+if (!output) {
+  throw new Error(`Gitlink ausente para ${submodulePath}.`);
+}
+
+const parts = output.split(/\s+/);
+const actualCommit = parts[1];
+
+if (actualCommit !== expectedCommit) {
+  throw new Error(
+    `Gitlink divergente para ${submodulePath}. esperado=${expectedCommit} atual=${actualCommit}`,
+  );
+}
+
+console.log(
+  `Composicao confirmada: ${submodulePath} aponta para ${actualCommit}.`,
+);


### PR DESCRIPTION
Atende a issue `ControleOnline/app-community#76`.

## O que mudou
- atualiza `modules/controleonline/products` para o commit `1ecd687`, que ja publica a marcacao com `*` nas colunas obrigatorias do CSV de exemplo
- adiciona o workflow `Product Module Composition Check` no agregador para validar objetivamente que a composicao publicada em `api-community` aponta para o commit revisado do modulo de produtos
- registra um verificador leve em `tools/verify-products-module-pointer.cjs` para deixar a evidencia automatizada no proprio commit do agregador

## Impacto entre projetos
- `app-community`: issue agregadora do fluxo manager de importacao
- `api-community`: passa a publicar a composicao rastreavel do modulo `api-platform-products` no backend principal
- `api-whatsapp`: sem impacto identificado

## Validacao
- `node tools/verify-products-module-pointer.cjs`
- `git diff --check`
- workflow `Product Module Composition Check` aguardando execucao neste PR

## Observacoes
- o modulo dono continua em `ControleOnline/api-platform-products#2`, que ja traz o check `Product Import Template Check` verde no commit `1ecd687`
- este repositorio nao expoe branch `dev`, entao a revisao segue para `master` para manter o diff isolado e rastreavel