### PR TITLE
Fix Scrutinizer install blocked by PhpSpreadsheet advisories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         "nfephp-org/sped-nfe": "dev-master",
         "nfephp-org/sped-pos": "dev-master",
         "phpdocumentor/reflection-docblock": "^5.4",
-        "phpoffice/phpspreadsheet": "^4.1",
+        "phpoffice/phpspreadsheet": "^5.7",
         "symfony/asset": "^7.0",
         "symfony/console": "^7.0",
         "symfony/doctrine-messenger": "^7.0",


### PR DESCRIPTION
## Summary
- update `phpoffice/phpspreadsheet` from `^4.1` to `^5.7`
- unblock Scrutinizer's Composer resolution after the PHP runtime fix
- superseded by `#25`, recreated from the current `master` on branch `task-23`

## Context
After the Scrutinizer PHP runtime was pinned to `8.3.0`, the next failing run moved forward and started failing during `composer install`. The new failure is caused by the current `phpoffice/phpspreadsheet ^4.1` constraint being blocked by Composer security advisories.

This PR carried the right content, but its source branch no longer matched the current Developer branch-sync rule because it had drifted behind `master`.

## Change
- raise the package constraint to `^5.7`, which is a current maintained release line on Packagist and is not the advisory-blocked 4.x line

## Validation
- inspected the latest Scrutinizer email from May 9, 2026 at 20:21 UTC
- confirmed the failure occurs during dependency resolution, not during PHP build
- checked that this repository references `PhpSpreadsheet` through `composer.json`
- confirmed the branch was superseded by `task-23` rebased from current `master`

Closes #23