### PR TITLE
Fix Scrutinizer install blocked by PhpSpreadsheet advisories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         "nfephp-org/sped-nfe": "dev-master",
         "nfephp-org/sped-pos": "dev-master",
         "phpdocumentor/reflection-docblock": "^5.4",
-        "phpoffice/phpspreadsheet": "^4.1",
+        "phpoffice/phpspreadsheet": "^5.7",
         "symfony/asset": "^7.0",
         "symfony/console": "^7.0",
         "symfony/doctrine-messenger": "^7.0",


### PR DESCRIPTION
## Summary
- update `phpoffice/phpspreadsheet` from `^4.1` to `^5.7`
- recreate the fix on top of the current `master` using the expected `task-23` branch
- supersede `#24`, whose branch was still 8 commits behind `master`

## Context
Issue `#23` is tracking a Scrutinizer failure during `composer install` caused by the advisory-blocked `phpoffice/phpspreadsheet ^4.1` constraint. The previous PR `#24` had the right content, but its source branch had diverged from the current `master`, which no longer matched the Developer branch-sync rule.

## Change
- raise the package constraint to `^5.7` on a fresh branch derived from the current `master`
- keep the diff isolated to `composer.json`

## Validation
- confirmed issue `#23` is still open and owned by `agent:developer`
- confirmed the previous branch `fix/phpspreadsheet-scrutinizer-20260509` was `ahead_by=1` and `behind_by=8` relative to `master`
- confirmed the old PR `#24` diff only touched `composer.json`
- confirmed the current repository `master` already carries newer `.scrutinizer.yml` changes than the old branch

Closes #23