### PR TITLE
chore: sync master into task-19

### DIFF
--- a/.github/workflows/deploy-apinew-lavego.yml
+++ b/.github/workflows/deploy-apinew-lavego.yml
@@ -10,16 +10,16 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: "18.17.1"
-      - name: Update Controle Online
+      - name: Update API NEW LaveGo
         uses: appleboy/ssh-action@master
         with:
-          host: ${{ secrets.API_HOST }}
-          username: ${{ secrets.USER }}
-          key: ${{ secrets.CONTROLEONLINE }}
-          port: ${{ secrets.PORT }}
+          host: ${{ secrets.HOST_APINEW_LAVEGO }}
+          username: ${{ secrets.USER_APINEW_LAVEGO }}
+          key: ${{ secrets.PASS_APINEW_LAVEGO }}
+          port: ${{ secrets.PORT_APINEW_LAVEGO }}
           script: |
                   export PATH="/usr/local/bin:/usr/bin:/bin:$PATH"
-                  cd ~/sistemas/controleonline/api
+                  cd ~/api
                   git fetch origin
                   git checkout master
                   git reset --hard origin/master
@@ -56,4 +56,4 @@ jobs:
                   php -d opcache.enable_cli=0 bin/console about --env=prod --no-debug >/dev/null
                   php bin/console tenant:migrations:migrate --no-interaction
                   mkdir -p var/log
-                  nohup php bin/console tenant:messenger:consume async --domain=api.controleonline.com >> var/log/tenant-messenger-consume.log 2>&1 </dev/null &
+                  nohup php bin/console tenant:messenger:consume async --domain=apinew.lave-go.com >> var/log/tenant-messenger-consume.log 2>&1 </dev/null &

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -55,3 +55,5 @@ jobs:
                   rm -f var/cache/prod/serialization.php
                   php -d opcache.enable_cli=0 bin/console about --env=prod --no-debug >/dev/null
                   php bin/console tenant:migrations:migrate --no-interaction
+                  mkdir -p var/log
+                  nohup php bin/console tenant:messenger:consume async --domain=api.controleonline.com >> var/log/tenant-messenger-consume.log 2>&1 </dev/null &

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,8 @@
 - Pedidos de segunda a domingo entram na mesma invoice semanal da `Food99`, com vencimento na quarta-feira seguinte.
 
 ## Retorno de API
-- Toda resposta customizada interna deve seguir o padrão do `HydratorService`.
+- Toda resposta customizada interna deve seguir o padrão do `HydratorService`, com `@type: Error`, `hydra:title` e `hydra:description`.
+- Controllers nao devem devolver `{"error": ...}` em paralelo quando a resposta interna puder usar o envelope do `HydratorService`.
 - Exceções só são aceitáveis quando houver integração externa que imponha outro contrato.
 - Totais de listagens devem ser expostos pelo mecanismo de `summary` do backend, usando `CollectionSummary` ou resolver especifico. O frontend nao deve precisar somar a pagina carregada para exibir totais filtrados.
 - Quando uma listagem for consumida por `DefaultTable` React, o contrato de busca e ordenacao precisa existir no backend: `CustomOrFilter` ou equivalente para `search`, `OrderFilter` para os campos usados pelo store e `DateFilter` para periodos. Datas ordenam pelo valor persistido, nao por string formatada.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,7 @@
 - `Food99Service` nao deve criar invoices inline quando o pedido nasce; a geracao e o backfill ficam centralizados em `MarketplaceOrderFinancialGenerationService`.
 - Em invoices de `Food99`, `iFood` so pode existir como contexto legado de estado do pedido, nunca como nome de conta, pagamento ou receptor.
 - Na `Food99`, a carteira de repasse da loja vem apenas da configuracao da tela de integracao e e a unica fonte valida para `provider_wallet`; nao inferir nem reaproveitar `99 Food` ou `iFood` como carteira da loja.
+- Nos pedidos filhos de logistica da `Food99`, `provider` e sempre o motoboy, `payer` e `99 Food`, `client` e a empresa do pedido pai, `deliveryContact` e o cliente do pedido pai, `addressOrigin` precisa estar sempre preenchido e o filho nao deve duplicar `otherInformations`.
 - Backfill de `Food99` deve ser idempotente e sempre reconstruir as invoices a partir do snapshot do pedido, sem consultar fontes externas adicionais.
 
 ## Regra Food99


### PR DESCRIPTION
Rotina operacional para levar o estado atual de `master` para `task-19` sem reescrever histórico.